### PR TITLE
Add table file stats api, fix cli default args value.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,7 +129,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn",
+ "syn 2.0.101",
  "which",
 ]
 
@@ -254,7 +254,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -339,6 +339,7 @@ dependencies = [
  "crossbeam-channel",
  "dashmap",
  "execute",
+ "get_fields",
  "rand",
  "rayon",
  "regex",
@@ -368,7 +369,7 @@ checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -379,7 +380,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -441,7 +442,7 @@ checksum = "ce8cd46a041ad005ab9c71263f9a0ff5b529eac0fe4cc9b4a20f4f0765d8cf4b"
 dependencies = [
  "execute-command-tokens",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -473,6 +474,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8c8444bc9d71b935156cc0ccab7f622180808af7867b1daae6547d773591703"
 dependencies = [
  "typenum",
+]
+
+[[package]]
+name = "get_fields"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fe8f7d930180be23f1fb00ad4cb9f3715f6fee2c077b33ee4da4969e1c60202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -731,7 +743,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9dee91521343f4c5c6a63edd65e54f31f5c92fe8978c40a4282f8372194c6a7d"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -753,7 +765,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -925,7 +937,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -951,6 +963,17 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -984,7 +1007,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1013,7 +1036,7 @@ checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1077,7 +1100,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
  "wasm-bindgen-shared",
 ]
 
@@ -1099,7 +1122,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1146,7 +1169,7 @@ checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1157,7 +1180,7 @@ checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1357,7 +1380,7 @@ checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ chrono = "0.4.41"
 clap = { version = "4.5.40", features = ["derive"] }
 crossbeam-channel = "0.5.15"
 dashmap = "6.1.0"
+get_fields = "0.1.0"
 rand = "0.9.1"
 rayon = "1.10.0"
 regex = "1.11.1"

--- a/src/args.rs
+++ b/src/args.rs
@@ -237,7 +237,7 @@ pub struct Stats {
     #[arg(short, long, default_value_t = ',', value_parser=get_valid_sep)]
     pub sep: char,
     /// Quote Char
-    #[arg(short, long, default_value_t = ',')]
+    #[arg(short, long, default_value_t = '"')]
     pub quote: char,
     /// Whether the file has a header
     #[arg(long, default_value_t = false)]

--- a/src/csv/stats.rs
+++ b/src/csv/stats.rs
@@ -6,11 +6,12 @@ use crate::utils::column_type::ColumnTypes;
 use crate::utils::file::column_n;
 use crate::utils::filename::new_path;
 use crate::utils::progress::Progress;
-use crate::utils::reader::{ChunkReader, Task};
-use crossbeam_channel::{bounded, unbounded, Sender};
+use crate::utils::reader::{ChunkReader};
+use crossbeam_channel::{bounded, unbounded};
 use rayon::ThreadPoolBuilder;
 use std::fs::File;
 use std::io::{BufWriter, Write};
+use crate::utils::chunk::{parse_chunk, ChunkResult};
 
 impl Stats {
     pub fn csv_run(&self) -> CliResult {
@@ -110,21 +111,4 @@ impl Stats {
 
         Ok(())
     }
-}
-
-struct ChunkResult {
-    bytes: usize,
-    stat: ColumnStats,
-}
-
-fn parse_chunk(task: Task, tx: Sender<ChunkResult>, mut stat: ColumnStats, sep: char, quote: char) {
-    for l in task.lines {
-        stat.parse_line(&l, sep, quote)
-    }
-
-    tx.send(ChunkResult {
-        bytes: task.bytes,
-        stat,
-    })
-    .unwrap()
 }

--- a/src/csv_lib/mod.rs
+++ b/src/csv_lib/mod.rs
@@ -1,3 +1,4 @@
 pub mod count;
 pub mod head;
 pub mod headers;
+pub mod stats;

--- a/src/csv_lib/stats.rs
+++ b/src/csv_lib/stats.rs
@@ -1,0 +1,112 @@
+use std::path::PathBuf;
+use crossbeam_channel::{bounded, unbounded};
+use rayon::ThreadPoolBuilder;
+use crate::utils::chunk::{parse_chunk, ChunkResult};
+use crate::utils::column::Columns;
+use crate::utils::column_stats::{CStat, ColumnStats};
+use crate::utils::column_type::ColumnTypes;
+use crate::utils::file::column_n;
+use crate::utils::progress::Progress;
+use crate::utils::reader::ChunkReader;
+use crate::utils::return_result::{CliResultData, ResultData};
+use crate::utils::row_split::CsvRowSplitter;
+
+pub fn csv_stats(
+    file: &PathBuf,
+    sep: char,
+    quote: char,
+    no_header: bool,
+    cols: String,
+) -> CliResultData {
+
+    let mut result_data = ResultData::new();
+    result_data.insert_header(CStat::get_fields.iter().map(|f| f.to_string()).collect());
+
+    // Column
+    let cols = Columns::new(cols.as_str())
+        .total_col_of(file, sep, quote)
+        .parse();
+    let Some(col_type) =
+        ColumnTypes::guess_from_csv(file, sep, quote, no_header, &cols)?
+    else {
+        return Ok(Some(result_data));
+    };
+
+    // open file
+    let mut rdr = ChunkReader::new(file)?;
+
+    // header
+    let name = if no_header {
+        let Some(n) = column_n(file, sep, quote)? else {
+            return Ok(Some(result_data));
+        };
+        cols.artificial_n_cols(n)
+    } else {
+        let Some(r) = rdr.next() else { return Ok(Some(result_data)) };
+        CsvRowSplitter::new(&r?, sep, quote)
+            .map(|i| i.to_owned())
+            .collect::<Vec<_>>()
+    };
+
+    // stats holder
+    let mut stat = ColumnStats::new(&col_type, &name);
+    let empty_stat = stat.clone();
+
+    // parallel channels
+    let (tx_chunk, rx_chunk) = bounded(2);
+    let (tx_chunk_n_control, rx_chunk_n_control) = bounded(200);
+    let (tx_result, rx_result) = unbounded();
+
+    // progress bar
+    let mut prog = Progress::new();
+
+    // threadpool
+    let pool = ThreadPoolBuilder::new().build().unwrap();
+
+    // read
+    pool.spawn(move || rdr.send_to_channel_by_chunks(tx_chunk, 50_000));
+
+    // parallel process
+    pool.scope(|s| {
+        // add chunk to threadpool for process
+        s.spawn(|_| {
+            for task in rx_chunk {
+                tx_chunk_n_control.send(()).unwrap();
+
+                let tx = tx_result.clone();
+                let st = empty_stat.clone();
+                let sep_inner = sep;
+                let quote_inner = quote;
+                // println!("dispatch........");
+                pool.spawn(move || parse_chunk(task, tx, st, sep_inner, quote_inner));
+            }
+
+            drop(tx_result);
+            drop(tx_chunk_n_control);
+        });
+
+        // receive result
+        for ChunkResult { bytes, stat: o } in rx_result {
+            rx_chunk_n_control.recv().unwrap();
+            // println!("result-----------");
+            // this is bottleneck, merge two hashset is very slow.
+            stat.merge(o);
+
+            prog.add_bytes(bytes);
+            prog.add_chunks(1);
+            prog.print();
+        }
+
+        prog.clear();
+    });
+
+    // refine result
+    stat.cal_unique_and_mean();
+    result_data.insert_records(stat.stat.iter().map(|s|s.get_fields_values()));
+    // stat.print();
+
+    // println!("Total rows: {}", stat.rows);
+    prog.print_elapsed_time();
+
+    Ok(Some(result_data))
+}

--- a/src/excel_lib/mod.rs
+++ b/src/excel_lib/mod.rs
@@ -1,4 +1,5 @@
 pub mod count;
 pub mod head;
 pub mod headers;
+pub mod stats;
 // pub mod size;

--- a/src/excel_lib/stats.rs
+++ b/src/excel_lib/stats.rs
@@ -1,0 +1,51 @@
+use std::path::PathBuf;
+use crate::utils::column::Columns;
+use crate::utils::column_stats::{CStat, ColumnStats};
+use crate::utils::column_type::ColumnTypes;
+use crate::utils::reader::ExcelReader;
+use crate::utils::return_result::{CliResultData, ResultData};
+
+pub fn excel_stats(
+    file: &PathBuf,
+    no_header: bool,
+    cols: String,
+    sheet: usize,
+)-> CliResultData {
+    let mut result_data = ResultData::new();
+
+    // read file
+    let mut rdr = ExcelReader::new(file, sheet)?;
+
+    // Column type
+    let cols = Columns::new(cols.as_str()).total_col(rdr.column_n()).parse();
+    let col_type = ColumnTypes::guess_from_excel(&rdr, no_header, &cols).unwrap();
+
+    // header
+    let name = match no_header {
+        true => cols.artificial_n_cols(rdr.column_n()),
+        false => {
+            let Some(r) = rdr.next() else { return Ok(Some(result_data)) };
+            r.iter().map(|i| i.to_string()).collect::<Vec<_>>()
+        }
+    };
+    result_data.insert_header(CStat::get_fields.iter().map(|s| s.to_string()).collect());
+
+    // stats holder
+    let mut stat = ColumnStats::new(&col_type, &name);
+    println!("stat: {}", stat);
+
+    // read
+    rdr.iter()
+        .skip(rdr.next_called)
+        .for_each(|r| stat.parse_excel_row(r));
+
+    // refine result
+    stat.cal_unique_and_mean();
+    result_data.insert_records(stat.stat.iter().map(|s|s.get_fields_values()));
+    // print
+    // stat.print();
+
+    println!("Total rows: {}", stat.rows);
+
+    Ok(Some(result_data))
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@ mod general_lib;
 mod utils;
 
 use crate::utils::{file::is_excel, filename::full_path, return_result::CliResultData};
-
+pub use crate::utils::return_result::ResultData;
 // general
 pub use general_lib::size::file_size;
 
@@ -46,5 +46,23 @@ pub fn file_headers(file: &str, sep: char, quote: char, sheet: usize) -> CliResu
     match is_excel(&path) {
         true => excel_headers(&path, sheet),
         false => csv_headers(&path, sep, quote),
+    }
+}
+
+use csv_lib::stats::csv_stats;
+use excel_lib::stats::excel_stats;
+
+pub fn file_stats(
+    file: &str,
+    sep: char,
+    quote: char,
+    no_header: bool,
+    cols: String,
+    sheet: usize,
+) -> CliResultData {
+    let path = full_path(file);
+    match is_excel(&path) {
+        true => excel_stats(&path, no_header, cols, sheet),
+        false => csv_stats(&path, sep, quote, no_header, cols),
     }
 }

--- a/src/utils/chunk.rs
+++ b/src/utils/chunk.rs
@@ -1,0 +1,20 @@
+use crossbeam_channel::Sender;
+use crate::utils::column_stats::ColumnStats;
+use crate::utils::reader::Task;
+
+pub struct ChunkResult {
+    pub bytes: usize,
+    pub stat: ColumnStats,
+}
+
+pub fn parse_chunk(task: Task, tx: Sender<ChunkResult>, mut stat: ColumnStats, sep: char, quote: char) {
+    for l in task.lines {
+        stat.parse_line(&l, sep, quote)
+    }
+
+    tx.send(ChunkResult {
+        bytes: task.bytes,
+        stat,
+    })
+        .unwrap()
+}

--- a/src/utils/column_stats.rs
+++ b/src/utils/column_stats.rs
@@ -7,6 +7,7 @@ use ahash::HashSet;
 use calamine::Data;
 use rayon::prelude::*;
 use std::fmt::Display;
+use get_fields::GetFields;
 use tabled::{builder::Builder, settings::Style, Table};
 
 #[derive(Debug)]
@@ -17,7 +18,7 @@ pub struct ColumnStats {
     pub rows: usize,
 }
 
-#[derive(Debug)]
+#[derive(Debug, GetFields)]
 pub struct CStat {
     col_index: usize,
     col_type: ColumnType,
@@ -199,6 +200,24 @@ impl Display for ColumnStats {
 }
 
 impl CStat {
+
+    pub fn get_fields_values(&self) -> Vec<String> {
+        vec![
+            self.col_index.to_string(),
+            self.col_type.to_string(),
+            self.name.clone(),
+            self.min_fmt(),
+            self.max_fmt(),
+            self.min_string.clone(),
+            self.max_string.clone(),
+            self.mean_fmt(),
+            self.unique_fmt(),
+            self.null.to_string(),
+            self.total.to_string(),
+            String::new(),
+        ]
+    }
+
     pub fn parse(&mut self, f: &str) {
         if util::is_null(f) {
             self.null += 1;

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -20,3 +20,4 @@ pub mod to;
 pub mod util;
 pub mod writer;
 pub mod return_result;
+pub mod chunk;

--- a/src/utils/return_result.rs
+++ b/src/utils/return_result.rs
@@ -32,4 +32,8 @@ impl ResultData {
     pub fn insert_record(&mut self, record: Vec<String>) {
         self.data.push(record);
     }
+
+    pub fn insert_records(&mut self, records: impl Iterator<Item=Vec<String>>) {
+        self.data.extend(records);
+    }
 }


### PR DESCRIPTION
    feat(lib): Add table file stats api.

    - Stats api return table stats fields and every column's compute info.
    - Bring in `get_fields` lib to auto generate struct fields names(CStat).
    - Split csv trunk struct and funcs to utils module.

    fix(cli-stats): Fix stats command `quote` args defautl value to `"`.

    - When csv row data cell value contains `,` will trigger error.
